### PR TITLE
Improve non-MD5 downloading support

### DIFF
--- a/obsidian_local_images_plus_latest/manifest.json
+++ b/obsidian_local_images_plus_latest/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-local-images-plus",
   "name": "Local Images Plus",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "minAppVersion": "1.0.3",
   "description": "Local Images Plus plugin searches for all external media links in your notes, downloads and saves them locally and adjusts the links in your notes to point to the saved files.",
   "author": "catalysm, aleksey-rezvov, Sergei Korneev",


### PR DESCRIPTION
This patch makes the plugin respect "Use MD5 for new attachments" being disabled on the function "Localize attachments for all your notes".