### PR TITLE
Fix Frontmatter images support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Obsidian Local Images Plus is a plugin for [Obsidian](https://obsidian.md/)
 - Downloading any filetypes from web
 - Saving attachments next to note in folder named after  note
 - Downloading files embedded in markdown tags from web to vault 
+- Downloading and localizing image URLs stored in note frontmatter
 - Saving base64 embedded images to vault
 - Converting PNG images to JPEG images with various quality
 - Attachments de-dulication by using MD5 hashing algorithm

--- a/src/contentProcessor.ts
+++ b/src/contentProcessor.ts
@@ -202,6 +202,127 @@ export function imageTagProcessor(app: Plugin,
 }
 
 
+type FrontmatterUrlCandidate = {
+  key: string;
+  index?: number;
+  value: string;
+};
+
+type FrontmatterUrlUpdate = {
+  key: string;
+  index?: number;
+  value: string;
+};
+
+function toFrontmatterWikilink(localizedValue: string): string {
+  if (!localizedValue) {
+    return localizedValue;
+  }
+
+  if (localizedValue.startsWith("![[") && localizedValue.endsWith("]]")) {
+    return localizedValue.slice(1);
+  }
+
+  const mdLinkMatch = localizedValue.match(/^!\[[^\]]*\]\((.+)\)$/);
+  if (mdLinkMatch?.[1]) {
+    const pathValue = trimAny(mdLinkMatch[1], [" "]);
+    return `[[${decodeURI(pathValue)}]]`;
+  }
+
+  return localizedValue;
+}
+
+export async function processFrontMatterUrls(app: Plugin,
+  noteFile: TFile,
+  settings: ISettings,
+  defaultdir: boolean
+) {
+
+  const frontmatterCandidates: FrontmatterUrlCandidate[] = [];
+  const updates: FrontmatterUrlUpdate[] = [];
+  let changed = false;
+  let error = false;
+  const filesArr: Array<string> = [];
+
+  await app.app.fileManager.processFrontMatter(noteFile, (frontmatter: any): any => {
+    if (!frontmatter) {
+      return frontmatter;
+    }
+
+    Object.entries(frontmatter).forEach(([key, value]) => {
+      if (typeof value === "string") {
+        const trimmedValue = value.trim();
+        if (isUrl(trimmedValue)) {
+          frontmatterCandidates.push({ key, value: trimmedValue });
+        }
+      }
+
+      if (Array.isArray(value)) {
+        value.forEach((arrVal, index) => {
+          if (typeof arrVal === "string") {
+            const trimmedValue = arrVal.trim();
+            if (isUrl(trimmedValue)) {
+              frontmatterCandidates.push({ key, index, value: trimmedValue });
+            }
+          }
+        });
+      }
+    });
+
+    return frontmatter;
+  });
+
+  if (!frontmatterCandidates.length) {
+    return { changed, error, filesArr };
+  }
+
+  const processImageTag = imageTagProcessor(app, noteFile, settings, defaultdir);
+
+  for (const candidate of frontmatterCandidates) {
+    const result = await processImageTag(candidate.value, "", candidate.value, "", "");
+
+    if (result === null) {
+      error = true;
+      continue;
+    }
+
+    const newValue = toFrontmatterWikilink(result[1]);
+    if (newValue && newValue !== candidate.value) {
+      updates.push({ key: candidate.key, index: candidate.index, value: newValue });
+      filesArr.push(newValue);
+      changed = true;
+    }
+  }
+
+  if (!updates.length) {
+    return { changed, error, filesArr };
+  }
+
+  await app.app.fileManager.processFrontMatter(noteFile, (frontmatter: any): any => {
+    if (!frontmatter) {
+      return frontmatter;
+    }
+
+    updates.forEach((update) => {
+      if (update.index === undefined) {
+        if (typeof frontmatter[update.key] === "string") {
+          frontmatter[update.key] = update.value;
+        }
+        return;
+      }
+
+      if (Array.isArray(frontmatter[update.key]) && typeof frontmatter[update.key][update.index] === "string") {
+        frontmatter[update.key][update.index] = update.value;
+      }
+    });
+
+    return frontmatter;
+  });
+
+  return { changed, error, filesArr };
+}
+
+
 
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {
   getMDir,
   getRDir,
   FrontMatterParser,
+  processFrontMatterUrls,
 } from "./contentProcessor"
 
 import {
@@ -321,10 +322,18 @@ export default class LocalImagesPlugin extends Plugin {
 
     const content = await this.app.vault.cachedRead(file)
     if (content.length == 0) {return null}
+
+    const frontmatterResult = await processFrontMatterUrls(this,
+      file,
+      this.settings,
+      defaultdir
+    )
+
+    const contentAfterFrontmatter = await this.app.vault.cachedRead(file)
       
 
     const fixedContent = await replaceAsync(
-      content,
+      contentAfterFrontmatter,
       MD_SEARCH_PATTERN,
       imageTagProcessor(this,
         file,
@@ -334,14 +343,20 @@ export default class LocalImagesPlugin extends Plugin {
     )
 
 
+    const contentChanged = contentAfterFrontmatter != fixedContent[0]
+    const hasChanges = frontmatterResult.changed || contentChanged
+    const hasErrors = frontmatterResult.error || fixedContent[1] === true
+    const createdFiles = [...frontmatterResult.filesArr, ...fixedContent[2]]
 
 
 
-    if (content != fixedContent[0] && fixedContent[1] === false) {
+    if (hasChanges && hasErrors === false) {
       this.modifiedQueue.remove(file)
-      await this.app.vault.modify(file, fixedContent[0])
+      if (contentChanged) {
+        await this.app.vault.modify(file, fixedContent[0])
+      }
 
-      fixedContent[2].forEach((element: string) => {
+      createdFiles.forEach((element: string) => {
         this.newfCreatedByDownloader.push(element)
       })
 
@@ -349,12 +364,14 @@ export default class LocalImagesPlugin extends Plugin {
 
     }
 
-    else if (content != fixedContent[0] && fixedContent[1] === true) {
+    else if (hasChanges && hasErrors === true) {
 
       this.modifiedQueue.remove(file)
-      await this.app.vault.modify(file, fixedContent[0])
+      if (contentChanged) {
+        await this.app.vault.modify(file, fixedContent[0])
+      }
 
-      fixedContent[2].forEach((element: string) => {
+      createdFiles.forEach((element: string) => {
         this.newfCreatedByDownloader.push(element)
       })
 


### PR DESCRIPTION
Fixes #20

1. Added frontmatter URL localization logic in contentProcessor.ts
- New function: processFrontMatterUrls
- Scans frontmatter keys for:
  - string URL values
  - string URLs inside arrays
- Reuses the existing download/hash/dedup/link-generation pipeline via imageTagProcessor, so behavior matches markdown image localization.
- Writes updated localized values back through Obsidian frontmatter API.

2. Wired frontmatter processing into page flow in main.ts
- processPage now:
  - runs processFrontMatterUrls first
  - re-reads content
  - runs existing markdown replacement
  - merges change/error state from both paths
- Keeps existing queue cleanup + notifications, and avoids unnecessary file modify calls if only frontmatter changed.

3. Documented feature in README in README.md
- Added feature bullet for frontmatter image URL localization.